### PR TITLE
Add larva infusion GUI and update storage caps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,5 +64,11 @@
             <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/maks/beesPlugin/BeesPlugin.java
+++ b/src/main/java/org/maks/beesPlugin/BeesPlugin.java
@@ -1,13 +1,57 @@
 package org.maks.beesPlugin;
 
+import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.beesPlugin.command.HiveCommand;
+import org.maks.beesPlugin.config.BeesConfig;
+import org.maks.beesPlugin.gui.HiveGui;
+import org.maks.beesPlugin.gui.HiveMenuGui;
+import org.maks.beesPlugin.gui.InfusionGui;
+import org.maks.beesPlugin.hive.HiveManager;
+import net.milkbowl.vault.economy.Economy;
 
 public final class BeesPlugin extends JavaPlugin {
 
+    private BeesConfig beesConfig;
+    private HiveManager hiveManager;
+    private Economy economy;
+    private HiveGui hiveGui;
+    private HiveMenuGui hiveMenuGui;
+    private InfusionGui infusionGui;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        saveDefaultConfig();
+        beesConfig = new BeesConfig(getConfig());
+        hiveManager = new HiveManager(beesConfig);
+        setupEconomy();
+        hiveGui = new HiveGui(hiveManager, beesConfig);
+        infusionGui = new InfusionGui(beesConfig);
+        hiveMenuGui = new HiveMenuGui(hiveManager, beesConfig, economy, hiveGui, infusionGui);
 
+        if (getCommand("hive") != null) {
+            getCommand("hive").setExecutor(new HiveCommand(hiveMenuGui));
+        }
+        getServer().getPluginManager().registerEvents(hiveGui, this);
+        getServer().getPluginManager().registerEvents(hiveMenuGui, this);
+        getServer().getPluginManager().registerEvents(infusionGui, this);
+
+        long tick = beesConfig.tickSeconds * 20L;
+        getServer().getScheduler().runTaskTimer(this, () -> {
+            long now = System.currentTimeMillis() / 1000;
+            hiveManager.tickAll(now);
+        }, tick, tick);
+    }
+
+    private void setupEconomy() {
+        try {
+            RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
+            if (rsp != null) {
+                economy = rsp.getProvider();
+            }
+        } catch (NoClassDefFoundError e) {
+            getLogger().warning("Vault not found, economy disabled");
+        }
     }
 
     @Override
@@ -15,3 +59,4 @@ public final class BeesPlugin extends JavaPlugin {
         // Plugin shutdown logic
     }
 }
+

--- a/src/main/java/org/maks/beesPlugin/command/HiveCommand.java
+++ b/src/main/java/org/maks/beesPlugin/command/HiveCommand.java
@@ -1,0 +1,27 @@
+package org.maks.beesPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.maks.beesPlugin.gui.HiveMenuGui;
+
+public class HiveCommand implements CommandExecutor {
+
+    private final HiveMenuGui menu;
+
+    public HiveCommand(HiveMenuGui menu) {
+        this.menu = menu;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players");
+            return true;
+        }
+        menu.open(player);
+        return true;
+    }
+}
+

--- a/src/main/java/org/maks/beesPlugin/config/BeesConfig.java
+++ b/src/main/java/org/maks/beesPlugin/config/BeesConfig.java
@@ -1,0 +1,120 @@
+package org.maks.beesPlugin.config;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.maks.beesPlugin.hive.Tier;
+import org.maks.beesPlugin.hive.BeeType;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class BeesConfig {
+    public final int tickSeconds;
+    public final double unitPerBottle;
+    public final int offlineCapHours;
+
+    public final double baseRare;
+    public final double baseLegendary;
+
+    public final Map<Tier, WorkerConfig> workers = new EnumMap<>(Tier.class);
+    public final Map<Tier, DroneConfig> drones = new EnumMap<>(Tier.class);
+    public final Map<Tier, QueenConfig> queens = new EnumMap<>(Tier.class);
+
+    public final int workerSlots;
+    public final int droneSlots;
+    public final int queenSlots;
+
+    public final int maxHivesPerPlayer;
+    public final double hiveCostBase;
+    public final double hiveCostGrowth;
+
+    public final int honeyStorageLimit;
+    public final int larvaeStorageLimit;
+
+    public final Map<Tier, InfusionCost> infusionCost = new EnumMap<>(Tier.class);
+    public final Map<Tier, Map<BeeType, Double>> infusionTypeWeights = new EnumMap<>(Tier.class);
+    public final Map<Tier, TierShift> infusionTierShift = new EnumMap<>(Tier.class);
+
+    public BeesConfig(FileConfiguration config) {
+        ConfigurationSection bees = config.getConfigurationSection("bees");
+        tickSeconds = bees.getInt("tick_seconds", 10);
+        unitPerBottle = bees.getDouble("unit_per_bottle", 60.0);
+        offlineCapHours = bees.getInt("offline_cap_hours", 8);
+
+        ConfigurationSection rarity = bees.getConfigurationSection("rarity");
+        baseRare = rarity.getDouble("base_rare", 0.05);
+        baseLegendary = rarity.getDouble("base_legendary", 0.005);
+
+        ConfigurationSection workerSec = bees.getConfigurationSection("workers");
+        for (String key : workerSec.getKeys(false)) {
+            Tier tier = Tier.valueOf(key);
+            workers.put(tier, new WorkerConfig(workerSec.getConfigurationSection(key).getDouble("base_honey_per_tick")));
+        }
+
+        ConfigurationSection droneSec = bees.getConfigurationSection("drones");
+        for (String key : droneSec.getKeys(false)) {
+            Tier tier = Tier.valueOf(key);
+            ConfigurationSection cs = droneSec.getConfigurationSection(key);
+            drones.put(tier, new DroneConfig(cs.getDouble("honey_penalty_per_tick"), cs.getDouble("larvae_per_tick")));
+        }
+
+        ConfigurationSection queenSec = bees.getConfigurationSection("queens");
+        for (String key : queenSec.getKeys(false)) {
+            Tier tier = Tier.valueOf(key);
+            ConfigurationSection cs = queenSec.getConfigurationSection(key);
+            queens.put(tier, new QueenConfig(cs.getDouble("multiplier"), cs.getDouble("rarity_bonus")));
+        }
+
+        ConfigurationSection slots = bees.getConfigurationSection("hive_slots");
+        workerSlots = slots.getInt("worker", 6);
+        droneSlots = slots.getInt("drone", 2);
+        queenSlots = slots.getInt("queen", 1);
+
+        ConfigurationSection ownership = bees.getConfigurationSection("ownership");
+        maxHivesPerPlayer = ownership.getInt("max_hives_per_player", 10);
+        ConfigurationSection hiveCost = ownership.getConfigurationSection("hive_cost");
+        hiveCostBase = hiveCost.getDouble("base", 100000000);
+        hiveCostGrowth = hiveCost.getDouble("growth", 2.0);
+
+        honeyStorageLimit = bees.getInt("honey_storage_limit", 16);
+        larvaeStorageLimit = bees.getInt("larvae_storage_limit", 64);
+
+        ConfigurationSection infCost = bees.getConfigurationSection("infusion_cost");
+        for (String key : infCost.getKeys(false)) {
+            Tier tier = Tier.valueOf(key);
+            ConfigurationSection cs = infCost.getConfigurationSection(key);
+            infusionCost.put(tier, new InfusionCost(
+                    cs.getInt("honey_I", 0),
+                    cs.getInt("honey_II", 0),
+                    cs.getInt("honey_III", 0)
+            ));
+        }
+
+        ConfigurationSection typeWeights = bees.getConfigurationSection("infusion_type_weights");
+        for (String key : typeWeights.getKeys(false)) {
+            Tier tier = Tier.valueOf(key);
+            ConfigurationSection cs = typeWeights.getConfigurationSection(key);
+            Map<BeeType, Double> map = new EnumMap<>(BeeType.class);
+            map.put(BeeType.WORKER, cs.getDouble("worker"));
+            map.put(BeeType.DRONE, cs.getDouble("drone"));
+            map.put(BeeType.QUEEN, cs.getDouble("queen"));
+            infusionTypeWeights.put(tier, map);
+        }
+
+        ConfigurationSection tierShift = bees.getConfigurationSection("infusion_tier_shift");
+        for (String key : tierShift.getKeys(false)) {
+            Tier tier = Tier.valueOf(key);
+            ConfigurationSection cs = tierShift.getConfigurationSection(key);
+            infusionTierShift.put(tier, new TierShift(
+                    cs.getDouble("down1"),
+                    cs.getDouble("same"),
+                    cs.getDouble("up1"),
+                    cs.getDouble("up2")
+            ));
+        }
+    }
+
+    public record InfusionCost(int honeyI, int honeyII, int honeyIII) {}
+
+    public record TierShift(double down1, double same, double up1, double up2) {}
+}

--- a/src/main/java/org/maks/beesPlugin/config/DroneConfig.java
+++ b/src/main/java/org/maks/beesPlugin/config/DroneConfig.java
@@ -1,0 +1,4 @@
+package org.maks.beesPlugin.config;
+
+public record DroneConfig(double honeyPenaltyPerTick, double larvaePerTick) {
+}

--- a/src/main/java/org/maks/beesPlugin/config/QueenConfig.java
+++ b/src/main/java/org/maks/beesPlugin/config/QueenConfig.java
@@ -1,0 +1,4 @@
+package org.maks.beesPlugin.config;
+
+public record QueenConfig(double multiplier, double rarityBonus) {
+}

--- a/src/main/java/org/maks/beesPlugin/config/WorkerConfig.java
+++ b/src/main/java/org/maks/beesPlugin/config/WorkerConfig.java
@@ -1,0 +1,4 @@
+package org.maks.beesPlugin.config;
+
+public record WorkerConfig(double baseHoneyPerTick) {
+}

--- a/src/main/java/org/maks/beesPlugin/gui/HiveGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/HiveGui.java
@@ -1,0 +1,111 @@
+package org.maks.beesPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.maks.beesPlugin.config.BeesConfig;
+import org.maks.beesPlugin.hive.BeeType;
+import org.maks.beesPlugin.hive.Hive;
+import org.maks.beesPlugin.hive.HiveManager;
+import org.maks.beesPlugin.hive.Tier;
+import org.maks.beesPlugin.item.BeeItems;
+
+import java.util.*;
+
+public class HiveGui implements Listener {
+
+    private final HiveManager hiveManager;
+    private final BeesConfig config;
+    private final Map<UUID, Integer> open = new HashMap<>();
+
+    public HiveGui(HiveManager hiveManager, BeesConfig config) {
+        this.hiveManager = hiveManager;
+        this.config = config;
+    }
+
+    public void open(Player player, int index) {
+        List<Hive> list = hiveManager.getHives(player.getUniqueId());
+        if (index < 0 || index >= list.size()) {
+            player.sendMessage(ChatColor.RED + "No hive at that index");
+            return;
+        }
+        Hive hive = list.get(index);
+        Inventory inv = Bukkit.createInventory(player, 9, "Hive " + (index + 1));
+        int w = 0;
+        for (Tier t : hive.getWorkers()) {
+            inv.setItem(w++, BeeItems.createBee(BeeType.WORKER, t));
+        }
+        if (hive.getQueen() != null) {
+            inv.setItem(6, BeeItems.createBee(BeeType.QUEEN, hive.getQueen()));
+        }
+        int d = 7;
+        for (Tier t : hive.getDrones()) {
+            inv.setItem(d++, BeeItems.createBee(BeeType.DRONE, t));
+        }
+        open.put(player.getUniqueId(), index);
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        UUID id = event.getPlayer().getUniqueId();
+        Integer idx = open.remove(id);
+        if (idx == null) return;
+
+        List<Hive> list = hiveManager.getHives(id);
+        if (idx < 0 || idx >= list.size()) return;
+        Hive hive = list.get(idx);
+        Inventory inv = event.getInventory();
+
+        hive.setQueen(null);
+        hive.getWorkers().clear();
+        hive.getDrones().clear();
+
+        ItemStack queenStack = inv.getItem(6);
+        if (queenStack != null) {
+            BeeItems.BeeItem bee = BeeItems.parse(queenStack);
+            if (bee != null && bee.type() == BeeType.QUEEN && queenStack.getAmount() == 1) {
+                hive.setQueen(bee.tier());
+            } else {
+                giveBack(event.getPlayer(), queenStack);
+                inv.setItem(6, null);
+            }
+        }
+
+        for (int i = 0; i < config.workerSlots; i++) {
+            ItemStack it = inv.getItem(i);
+            if (it == null) continue;
+            BeeItems.BeeItem bee = BeeItems.parse(it);
+            if (bee != null && bee.type() == BeeType.WORKER && it.getAmount() == 1) {
+                hive.getWorkers().add(bee.tier());
+            } else {
+                giveBack(event.getPlayer(), it);
+            }
+        }
+
+        for (int i = 0; i < config.droneSlots; i++) {
+            int slot = 7 + i;
+            ItemStack it = inv.getItem(slot);
+            if (it == null) continue;
+            BeeItems.BeeItem bee = BeeItems.parse(it);
+            if (bee != null && bee.type() == BeeType.DRONE && it.getAmount() == 1) {
+                hive.getDrones().add(bee.tier());
+            } else {
+                giveBack(event.getPlayer(), it);
+            }
+        }
+    }
+
+    private void giveBack(Player player, ItemStack stack) {
+        Map<Integer, ItemStack> left = player.getInventory().addItem(stack);
+        for (ItemStack s : left.values()) {
+            player.getWorld().dropItem(player.getLocation(), s);
+        }
+    }
+}
+

--- a/src/main/java/org/maks/beesPlugin/gui/HiveMenuGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/HiveMenuGui.java
@@ -1,0 +1,127 @@
+package org.maks.beesPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.beesPlugin.config.BeesConfig;
+import org.maks.beesPlugin.hive.Hive;
+import org.maks.beesPlugin.hive.HiveManager;
+import org.maks.beesPlugin.hive.BeeType;
+import org.maks.beesPlugin.hive.Tier;
+import org.maks.beesPlugin.item.BeeItems;
+import org.maks.beesPlugin.gui.InfusionGui;
+import net.milkbowl.vault.economy.Economy;
+
+import java.util.*;
+
+public class HiveMenuGui implements Listener {
+
+    private final HiveManager hiveManager;
+    private final BeesConfig config;
+    private final Economy economy;
+    private final HiveGui hiveGui;
+    private final InfusionGui infusionGui;
+    private final Set<UUID> viewers = new HashSet<>();
+
+    public HiveMenuGui(HiveManager hiveManager, BeesConfig config, Economy economy, HiveGui hiveGui, InfusionGui infusionGui) {
+        this.hiveManager = hiveManager;
+        this.config = config;
+        this.economy = economy;
+        this.hiveGui = hiveGui;
+        this.infusionGui = infusionGui;
+    }
+
+    public void open(Player player) {
+        Inventory inv = Bukkit.createInventory(player, 27, "Your Hives");
+        List<Hive> list = hiveManager.getHives(player.getUniqueId());
+        for (int i = 0; i < config.maxHivesPerPlayer; i++) {
+            ItemStack item;
+            if (i < list.size()) {
+                item = new ItemStack(Material.BEE_NEST);
+                ItemMeta meta = item.getItemMeta();
+                meta.setDisplayName(ChatColor.YELLOW + "Hive " + (i + 1));
+                meta.setLore(List.of(ChatColor.GRAY + "Click to manage"));
+                item.setItemMeta(meta);
+            } else {
+                double cost = hiveManager.getNextHiveCost(player.getUniqueId());
+                item = new ItemStack(Material.BARRIER);
+                ItemMeta meta = item.getItemMeta();
+                meta.setDisplayName(ChatColor.RED + "Buy Hive");
+                meta.setLore(List.of(ChatColor.GRAY + "Cost: " + String.format("%.0f", cost)));
+                item.setItemMeta(meta);
+            }
+            inv.setItem(i, item);
+        }
+        ItemStack collect = new ItemStack(Material.HONEY_BOTTLE);
+        ItemMeta meta = collect.getItemMeta();
+        meta.setDisplayName(ChatColor.GREEN + "Collect All");
+        collect.setItemMeta(meta);
+        inv.setItem(26, collect);
+
+        ItemStack infuse = new ItemStack(Material.BEACON);
+        ItemMeta m2 = infuse.getItemMeta();
+        m2.setDisplayName(ChatColor.AQUA + "Infuse Larva");
+        infuse.setItemMeta(m2);
+        inv.setItem(25, infuse);
+        viewers.add(player.getUniqueId());
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        UUID id = event.getWhoClicked().getUniqueId();
+        if (!viewers.contains(id)) return;
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+        int slot = event.getRawSlot();
+        List<Hive> list = hiveManager.getHives(id);
+        if (slot < config.maxHivesPerPlayer) {
+            if (slot < list.size()) {
+                hiveGui.open(player, slot);
+            } else {
+                if (list.size() >= config.maxHivesPerPlayer) return;
+                double cost = hiveManager.getNextHiveCost(id);
+                if (economy != null) {
+                    if (!economy.has(player, cost)) {
+                        player.sendMessage(ChatColor.RED + "Not enough money");
+                        return;
+                    }
+                    var resp = economy.withdrawPlayer(player, cost);
+                    if (!resp.transactionSuccess()) {
+                        player.sendMessage(ChatColor.RED + "Payment failed");
+                        return;
+                    }
+                }
+                Hive hive = hiveManager.createHive(id, System.currentTimeMillis() / 1000);
+                if (hive != null && list.isEmpty()) {
+                    player.getInventory().addItem(BeeItems.createBee(BeeType.QUEEN, Tier.I));
+                    player.getInventory().addItem(BeeItems.createBee(BeeType.WORKER, Tier.I));
+                    player.getInventory().addItem(BeeItems.createBee(BeeType.WORKER, Tier.I));
+                    player.getInventory().addItem(BeeItems.createBee(BeeType.DRONE, Tier.I));
+                }
+                player.sendMessage(ChatColor.GREEN + "Bought new hive");
+                open(player);
+            }
+        } else if (slot == 26) {
+            hiveManager.collectAll(player);
+            player.sendMessage(ChatColor.GREEN + "Collected hive products");
+            open(player);
+        } else if (slot == 25) {
+            infusionGui.open(player);
+        }
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        viewers.remove(event.getPlayer().getUniqueId());
+    }
+}
+

--- a/src/main/java/org/maks/beesPlugin/gui/InfusionGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/InfusionGui.java
@@ -1,0 +1,152 @@
+package org.maks.beesPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.maks.beesPlugin.config.BeesConfig;
+import org.maks.beesPlugin.hive.BeeType;
+import org.maks.beesPlugin.hive.Tier;
+import org.maks.beesPlugin.item.BeeItems;
+
+import java.util.*;
+
+public class InfusionGui implements Listener {
+
+    private final BeesConfig config;
+    private final Set<UUID> viewers = new HashSet<>();
+    private final Random random = new Random();
+
+    public InfusionGui(BeesConfig config) {
+        this.config = config;
+    }
+
+    public void open(Player player) {
+        Inventory inv = Bukkit.createInventory(player, 9, "Infuse Larva");
+        viewers.add(player.getUniqueId());
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        UUID id = event.getPlayer().getUniqueId();
+        if (!viewers.remove(id)) return;
+
+        Player player = (Player) event.getPlayer();
+        Inventory inv = event.getInventory();
+
+        ItemStack larvaStack = inv.getItem(4);
+        BeeItems.BeeItem larva = BeeItems.parse(larvaStack);
+        if (larva == null || larva.type() != BeeType.LARVA || larvaStack.getAmount() != 1) {
+            returnItems(player, inv.getContents());
+            player.sendMessage(ChatColor.RED + "Place exactly one larva in the middle.");
+            return;
+        }
+        Tier larvaTier = larva.tier();
+        BeesConfig.InfusionCost cost = config.infusionCost.get(larvaTier);
+        if (cost == null) {
+            returnItems(player, inv.getContents());
+            return;
+        }
+
+        EnumMap<Tier, Integer> honeyCounts = new EnumMap<>(Tier.class);
+        boolean invalid = false;
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (i == 4) continue;
+            ItemStack stack = inv.getItem(i);
+            if (stack == null) continue;
+            Tier t = BeeItems.parseHoney(stack);
+            if (t == null) {
+                invalid = true;
+                break;
+            }
+            honeyCounts.merge(t, stack.getAmount(), Integer::sum);
+        }
+        if (invalid) {
+            returnItems(player, inv.getContents());
+            player.sendMessage(ChatColor.RED + "Only honey bottles around the larva are allowed.");
+            return;
+        }
+
+        if (honeyCounts.getOrDefault(Tier.I, 0) < cost.honeyI() ||
+            honeyCounts.getOrDefault(Tier.II, 0) < cost.honeyII() ||
+            honeyCounts.getOrDefault(Tier.III, 0) < cost.honeyIII()) {
+            returnItems(player, inv.getContents());
+            player.sendMessage(ChatColor.RED + "Not enough honey for infusion.");
+            return;
+        }
+
+        // return excess honey
+        int excessI = honeyCounts.getOrDefault(Tier.I, 0) - cost.honeyI();
+        int excessII = honeyCounts.getOrDefault(Tier.II, 0) - cost.honeyII();
+        int excessIII = honeyCounts.getOrDefault(Tier.III, 0) - cost.honeyIII();
+        List<ItemStack> extras = new ArrayList<>();
+        if (excessI > 0) {
+            ItemStack hi = BeeItems.createHoney(Tier.I);
+            hi.setAmount(excessI);
+            extras.add(hi);
+        }
+        if (excessII > 0) {
+            ItemStack hi = BeeItems.createHoney(Tier.II);
+            hi.setAmount(excessII);
+            extras.add(hi);
+        }
+        if (excessIII > 0) {
+            ItemStack hi = BeeItems.createHoney(Tier.III);
+            hi.setAmount(excessIII);
+            extras.add(hi);
+        }
+        returnItems(player, extras.toArray(new ItemStack[0]));
+
+        // determine bee type
+        Map<BeeType, Double> weights = config.infusionTypeWeights.get(larvaTier);
+        BeeType resultType = rollType(weights);
+
+        BeesConfig.TierShift shift = config.infusionTierShift.get(larvaTier);
+        int tierShift = rollTierShift(shift);
+        int newLevel = Math.min(3, Math.max(1, larvaTier.getLevel() + tierShift));
+        Tier resultTier = Tier.fromLevel(newLevel);
+
+        ItemStack bee = BeeItems.createBee(resultType, resultTier);
+        Map<Integer, ItemStack> left = player.getInventory().addItem(bee);
+        for (ItemStack s : left.values()) {
+            player.getWorld().dropItem(player.getLocation(), s);
+        }
+    }
+
+    private BeeType rollType(Map<BeeType, Double> weights) {
+        double total = 0;
+        for (double d : weights.values()) total += d;
+        double r = random.nextDouble() * total;
+        double cumulative = 0;
+        for (var e : weights.entrySet()) {
+            cumulative += e.getValue();
+            if (r <= cumulative) return e.getKey();
+        }
+        return BeeType.WORKER;
+    }
+
+    private int rollTierShift(BeesConfig.TierShift shift) {
+        double r = random.nextDouble();
+        if (r < shift.down1()) return -1;
+        r -= shift.down1();
+        if (r < shift.same()) return 0;
+        r -= shift.same();
+        if (r < shift.up1()) return 1;
+        return 2;
+    }
+
+    private void returnItems(Player player, ItemStack[] items) {
+        for (ItemStack stack : items) {
+            if (stack == null || stack.getType().isAir()) continue;
+            Map<Integer, ItemStack> left = player.getInventory().addItem(stack);
+            for (ItemStack s : left.values()) {
+                player.getWorld().dropItem(player.getLocation(), s);
+            }
+        }
+    }
+}

--- a/src/main/java/org/maks/beesPlugin/hive/BeeType.java
+++ b/src/main/java/org/maks/beesPlugin/hive/BeeType.java
@@ -1,0 +1,8 @@
+package org.maks.beesPlugin.hive;
+
+public enum BeeType {
+    WORKER,
+    DRONE,
+    QUEEN,
+    LARVA
+}

--- a/src/main/java/org/maks/beesPlugin/hive/Hive.java
+++ b/src/main/java/org/maks/beesPlugin/hive/Hive.java
@@ -1,0 +1,134 @@
+package org.maks.beesPlugin.hive;
+
+import org.maks.beesPlugin.config.BeesConfig;
+import org.maks.beesPlugin.config.DroneConfig;
+import org.maks.beesPlugin.config.QueenConfig;
+import org.maks.beesPlugin.config.WorkerConfig;
+
+import java.util.*;
+
+public class Hive {
+    private Tier queen; // null if none
+    private final List<Tier> workers = new ArrayList<>();
+    private final List<Tier> drones = new ArrayList<>();
+
+    private double honeyUnits = 0;
+    private double larvaeUnits = 0;
+
+    private final EnumMap<Tier, Integer> honeyStored = new EnumMap<>(Tier.class);
+    private final EnumMap<Tier, Integer> larvaeStored = new EnumMap<>(Tier.class);
+
+    private long lastTick; // epoch seconds
+
+    private final Random random = new Random();
+
+    public Hive(long now) {
+        this.lastTick = now;
+        for (Tier t : Tier.values()) {
+            honeyStored.put(t, 0);
+            larvaeStored.put(t, 0);
+        }
+    }
+
+    public Tier getQueen() {
+        return queen;
+    }
+
+    public void setQueen(Tier queen) {
+        this.queen = queen;
+    }
+
+    public List<Tier> getWorkers() {
+        return workers;
+    }
+
+    public List<Tier> getDrones() {
+        return drones;
+    }
+
+    public EnumMap<Tier, Integer> getHoneyStored() {
+        return honeyStored;
+    }
+
+    public EnumMap<Tier, Integer> getLarvaeStored() {
+        return larvaeStored;
+    }
+
+    public void tick(BeesConfig config, long now) {
+        long diff = now - lastTick;
+        long maxSeconds = config.offlineCapHours * 3600L;
+        if (diff > maxSeconds) diff = maxSeconds;
+        long ticks = diff / config.tickSeconds;
+        if (ticks <= 0) return;
+        for (long i = 0; i < ticks; i++) {
+            tickOnce(config);
+        }
+        lastTick += ticks * config.tickSeconds;
+    }
+
+    private void tickOnce(BeesConfig cfg) {
+        if (queen == null) return;
+        QueenConfig qc = cfg.queens.get(queen);
+
+        double base = 0;
+        for (Tier t : workers) {
+            WorkerConfig wc = cfg.workers.get(t);
+            base += wc.baseHoneyPerTick();
+        }
+        double cut = 0;
+        double larvae = 0;
+        Map<Tier, Double> larvaeWeights = new EnumMap<>(Tier.class);
+        for (Tier t : drones) {
+            DroneConfig dc = cfg.drones.get(t);
+            cut += dc.honeyPenaltyPerTick();
+            larvae += dc.larvaePerTick();
+            larvaeWeights.merge(t, dc.larvaePerTick(), Double::sum);
+        }
+        double net = Math.max(0, base - cut) * qc.multiplier();
+        double larv = larvae * qc.multiplier();
+
+        honeyUnits += net;
+        larvaeUnits += larv;
+
+        while (honeyUnits >= cfg.unitPerBottle) {
+            honeyUnits -= cfg.unitPerBottle;
+            Tier quality = rollHoneyTier(cfg, qc);
+            int current = honeyStored.get(quality);
+            if (current < cfg.honeyStorageLimit) {
+                honeyStored.put(quality, current + 1);
+            }
+        }
+
+        while (larvaeUnits >= 1.0) {
+            larvaeUnits -= 1.0;
+            Tier tier = rollLarvaTier(larvaeWeights);
+            int current = larvaeStored.get(tier);
+            if (current < cfg.larvaeStorageLimit) {
+                larvaeStored.put(tier, current + 1);
+            }
+        }
+    }
+
+    private Tier rollHoneyTier(BeesConfig cfg, QueenConfig qc) {
+        double rareChance = cfg.baseRare * (1.0 + qc.rarityBonus());
+        double legendChance = cfg.baseLegendary * (1.0 + 0.5 * qc.rarityBonus());
+        double r = random.nextDouble();
+        if (r < legendChance) return Tier.III;
+        if (r < legendChance + rareChance) return Tier.II;
+        return Tier.I;
+    }
+
+    private Tier rollLarvaTier(Map<Tier, Double> weights) {
+        double total = 0;
+        for (double w : weights.values()) total += w;
+        if (total <= 0) return Tier.I;
+        double r = random.nextDouble() * total;
+        double cumulative = 0;
+        for (Tier t : Tier.values()) {
+            double w = weights.getOrDefault(t, 0.0);
+            cumulative += w;
+            if (r <= cumulative) return t;
+        }
+        return Tier.I;
+    }
+}

--- a/src/main/java/org/maks/beesPlugin/hive/HiveManager.java
+++ b/src/main/java/org/maks/beesPlugin/hive/HiveManager.java
@@ -1,0 +1,79 @@
+package org.maks.beesPlugin.hive;
+
+import org.bukkit.entity.Player;
+import org.maks.beesPlugin.config.BeesConfig;
+import org.maks.beesPlugin.item.BeeItems;
+
+import java.util.*;
+
+public class HiveManager {
+    private final BeesConfig config;
+    private final Map<UUID, List<Hive>> hives = new HashMap<>();
+
+    public HiveManager(BeesConfig config) {
+        this.config = config;
+    }
+
+    public List<Hive> getHives(UUID uuid) {
+        return hives.computeIfAbsent(uuid, u -> new ArrayList<>());
+    }
+
+    public double getNextHiveCost(UUID uuid) {
+        int owned = getHives(uuid).size();
+        return config.hiveCostBase * Math.pow(config.hiveCostGrowth, owned);
+    }
+
+    public Hive createHive(UUID uuid, long now) {
+        List<Hive> list = getHives(uuid);
+        if (list.size() >= config.maxHivesPerPlayer) {
+            return null;
+        }
+        Hive hive = new Hive(now);
+        list.add(hive);
+        return hive;
+    }
+
+    public void tickAll(long now) {
+        for (List<Hive> list : hives.values()) {
+            for (Hive hive : list) {
+                hive.tick(config, now);
+            }
+        }
+    }
+
+    public void collectAll(Player player) {
+        List<Hive> list = getHives(player.getUniqueId());
+        for (Hive hive : list) {
+            for (Tier t : Tier.values()) {
+                int honey = hive.getHoneyStored().get(t);
+                int delivered = 0;
+                for (int i = 0; i < honey; i++) {
+                    var leftovers = player.getInventory().addItem(BeeItems.createHoney(t));
+                    if (!leftovers.isEmpty()) {
+                        // inventory full, put back remaining including this one
+                        hive.getHoneyStored().put(t, honey - delivered);
+                        break;
+                    }
+                    delivered++;
+                }
+                if (honey == delivered) {
+                    hive.getHoneyStored().put(t, 0);
+                }
+
+                int larva = hive.getLarvaeStored().get(t);
+                delivered = 0;
+                for (int i = 0; i < larva; i++) {
+                    var leftovers = player.getInventory().addItem(BeeItems.createBee(BeeType.LARVA, t));
+                    if (!leftovers.isEmpty()) {
+                        hive.getLarvaeStored().put(t, larva - delivered);
+                        break;
+                    }
+                    delivered++;
+                }
+                if (larva == delivered) {
+                    hive.getLarvaeStored().put(t, 0);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/maks/beesPlugin/hive/Tier.java
+++ b/src/main/java/org/maks/beesPlugin/hive/Tier.java
@@ -1,0 +1,26 @@
+package org.maks.beesPlugin.hive;
+
+public enum Tier {
+    I(1),
+    II(2),
+    III(3);
+
+    private final int level;
+
+    Tier(int level) {
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public static Tier fromLevel(int level) {
+        for (Tier t : values()) {
+            if (t.level == level) {
+                return t;
+            }
+        }
+        throw new IllegalArgumentException("Unknown tier: " + level);
+    }
+}

--- a/src/main/java/org/maks/beesPlugin/item/BeeItems.java
+++ b/src/main/java/org/maks/beesPlugin/item/BeeItems.java
@@ -1,0 +1,105 @@
+package org.maks.beesPlugin.item;
+
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.beesPlugin.hive.BeeType;
+import org.maks.beesPlugin.hive.Tier;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class BeeItems {
+
+    public static ItemStack createHoney(Tier tier) {
+        ItemStack item = new ItemStack(Material.HONEY_BOTTLE);
+        ItemMeta meta = item.getItemMeta();
+        meta.addEnchant(Enchantment.DURABILITY, 10, true);
+        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES);
+        String color = switch (tier) {
+            case I -> "§9";
+            case II -> "§5";
+            case III -> "§6";
+        };
+        meta.setDisplayName(color + "[ " + tier.getLevel() + " ] Honey Bottle");
+        meta.setLore(List.of("§o§7Applies a new §fQuality§7 to an item."));
+        meta.setUnbreakable(true);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    public static ItemStack createBee(BeeType type, Tier tier) {
+        Material material = switch (type) {
+            case WORKER, QUEEN, DRONE -> Material.BREAD;
+            case LARVA -> Material.COOKIE;
+        };
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        meta.addEnchant(Enchantment.DURABILITY, 10, true);
+        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES);
+        String color = switch (tier) {
+            case I -> "§9";
+            case II -> "§5";
+            case III -> "§6";
+        };
+        String name = color + "[ " + tier.getLevel() + " ] " + switch (type) {
+            case WORKER -> "Worker Bee";
+            case DRONE -> "Drone Bee";
+            case QUEEN -> "Queen Bee";
+            case LARVA -> "Bee Larva";
+        };
+        meta.setDisplayName(name);
+        meta.setUnbreakable(true);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    public record BeeItem(BeeType type, Tier tier) {}
+
+    private static final Pattern NAME_PATTERN = Pattern.compile("\\[ (\\d) \\] (.+)");
+
+    public static BeeItem parse(ItemStack item) {
+        if (item == null) return null;
+        Material type = item.getType();
+        if (type != Material.BREAD && type != Material.COOKIE) return null;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) return null;
+        String stripped = meta.getDisplayName().replaceAll("§[0-9a-fk-or]", "");
+        Matcher m = NAME_PATTERN.matcher(stripped);
+        if (!m.find()) return null;
+        int level;
+        try {
+            level = Integer.parseInt(m.group(1));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        Tier tier = Tier.fromLevel(level);
+        String name = m.group(2).toLowerCase();
+        BeeType beeType;
+        if (name.contains("queen")) beeType = BeeType.QUEEN;
+        else if (name.contains("worker")) beeType = BeeType.WORKER;
+        else if (name.contains("drone")) beeType = BeeType.DRONE;
+        else if (name.contains("larva")) beeType = BeeType.LARVA;
+        else return null;
+        return new BeeItem(beeType, tier);
+    }
+
+    public static Tier parseHoney(ItemStack item) {
+        if (item == null || item.getType() != Material.HONEY_BOTTLE) return null;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) return null;
+        String stripped = meta.getDisplayName().replaceAll("§[0-9a-fk-or]", "");
+        Matcher m = NAME_PATTERN.matcher(stripped);
+        if (!m.find()) return null;
+        int level;
+        try {
+            level = Integer.parseInt(m.group(1));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        return Tier.fromLevel(level);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,52 @@
+bees:
+  tick_seconds: 10
+  unit_per_bottle: 60
+  offline_cap_hours: 8
+
+  rarity:
+    base_rare: 0.05
+    base_legendary: 0.005
+
+  workers:
+    I:   { base_honey_per_tick: 0.03 }
+    II:  { base_honey_per_tick: 0.045 }
+    III: { base_honey_per_tick: 0.06 }
+  drones:
+    I:   { honey_penalty_per_tick: 0.02, larvae_per_tick: 0.01 }
+    II:  { honey_penalty_per_tick: 0.03, larvae_per_tick: 0.015 }
+    III: { honey_penalty_per_tick: 0.04, larvae_per_tick: 0.02 }
+  queens:
+    I:   { multiplier: 1.0, rarity_bonus: 0.05 }
+    II:  { multiplier: 1.2, rarity_bonus: 0.10 }
+    III: { multiplier: 1.5, rarity_bonus: 0.15 }
+
+  hive_slots:
+    worker: 6
+    drone: 2
+    queen: 1
+
+  infusion_cost:
+    I:   { honey_I: 6, honey_II: 0, honey_III: 0 }
+    II:  { honey_I: 0, honey_II: 3, honey_III: 0 }
+    III: { honey_I: 0, honey_II: 0, honey_III: 1 }
+  infusion_type_weights:
+    I:   { worker: 0.80, drone: 0.18, queen: 0.02 }
+    II:  { worker: 0.65, drone: 0.25, queen: 0.10 }
+    III: { worker: 0.45, drone: 0.30, queen: 0.25 }
+  infusion_tier_shift:
+    I:   { down1: 0.20, same: 0.80, up1: 0.00, up2: 0.00 }
+    II:  { down1: 0.00, same: 0.60, up1: 0.40, up2: 0.00 }
+    III: { down1: 0.00, same: 0.30, up1: 0.60, up2: 0.10 }
+
+  ownership:
+    max_hives_per_player: 10
+    hive_cost:
+      base: 100000000
+      growth: 2.0
+    starter_pack:
+      queen: I
+      workers: { I: 2 }
+      drones:  { I: 1 }
+ 
+    honey_storage_limit: 16
+    larvae_storage_limit: 64

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,3 +2,6 @@ name: beesPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.beesPlugin.BeesPlugin
 api-version: '1.20'
+commands:
+  hive:
+    description: Manage hives


### PR DESCRIPTION
## Summary
- allow larva infusion via dedicated GUI that consumes honey and spawns random bees
- parse honey bottle tiers and expose infusion settings in config
- cap stored honey at 16 bottles per tier and larvae at 64 to match stack sizes

## Testing
- `mvn -q -e package` *(PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a868caa7f4832a8930d0504be6c1af