### PR TITLE
Enforce transactional item rewards and GUI validation

### DIFF
--- a/src/main/java/org/maks/beesPlugin/gui/HiveGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/HiveGui.java
@@ -5,7 +5,11 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.maks.beesPlugin.config.BeesConfig;
@@ -49,6 +53,28 @@ public class HiveGui implements Listener {
         }
         open.put(player.getUniqueId(), index);
         player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        UUID id = event.getWhoClicked().getUniqueId();
+        if (!open.containsKey(id)) return;
+        if (event.isShiftClick() || event.getClick() == ClickType.NUMBER_KEY ||
+                event.getAction() == InventoryAction.COLLECT_TO_CURSOR) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onDrag(InventoryDragEvent event) {
+        UUID id = event.getWhoClicked().getUniqueId();
+        if (!open.containsKey(id)) return;
+        for (int slot : event.getRawSlots()) {
+            if (slot < event.getView().getTopInventory().getSize()) {
+                event.setCancelled(true);
+                break;
+            }
+        }
     }
 
     @EventHandler

--- a/src/main/java/org/maks/beesPlugin/gui/HiveMenuGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/HiveMenuGui.java
@@ -102,17 +102,29 @@ public class HiveMenuGui implements Listener {
                 }
                 Hive hive = hiveManager.createHive(id, System.currentTimeMillis() / 1000);
                 if (hive != null && list.isEmpty()) {
-                    player.getInventory().addItem(BeeItems.createBee(BeeType.QUEEN, Tier.I));
-                    player.getInventory().addItem(BeeItems.createBee(BeeType.WORKER, Tier.I));
-                    player.getInventory().addItem(BeeItems.createBee(BeeType.WORKER, Tier.I));
-                    player.getInventory().addItem(BeeItems.createBee(BeeType.DRONE, Tier.I));
+                    var starters = List.of(
+                            BeeItems.createBee(BeeType.QUEEN, Tier.I),
+                            BeeItems.createBee(BeeType.WORKER, Tier.I),
+                            BeeItems.createBee(BeeType.WORKER, Tier.I),
+                            BeeItems.createBee(BeeType.DRONE, Tier.I)
+                    );
+                    if (hiveManager.hasInventorySpace(player, new ArrayList<>(starters))) {
+                        for (ItemStack it : starters) {
+                            player.getInventory().addItem(it);
+                        }
+                    } else {
+                        player.sendMessage(ChatColor.RED + "Not enough inventory space for starter bees");
+                    }
                 }
                 player.sendMessage(ChatColor.GREEN + "Bought new hive");
                 open(player);
             }
         } else if (slot == 26) {
-            hiveManager.collectAll(player);
-            player.sendMessage(ChatColor.GREEN + "Collected hive products");
+            if (hiveManager.collectAll(player)) {
+                player.sendMessage(ChatColor.GREEN + "Collected hive products");
+            } else {
+                player.sendMessage(ChatColor.RED + "Make space in your inventory first");
+            }
             open(player);
         } else if (slot == 25) {
             infusionGui.open(player);

--- a/src/main/java/org/maks/beesPlugin/gui/InfusionGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/InfusionGui.java
@@ -5,7 +5,11 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.maks.beesPlugin.config.BeesConfig;
@@ -29,6 +33,28 @@ public class InfusionGui implements Listener {
         Inventory inv = Bukkit.createInventory(player, 9, "Infuse Larva");
         viewers.add(player.getUniqueId());
         player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        UUID id = event.getWhoClicked().getUniqueId();
+        if (!viewers.contains(id)) return;
+        if (event.isShiftClick() || event.getClick() == ClickType.NUMBER_KEY ||
+                event.getAction() == InventoryAction.COLLECT_TO_CURSOR) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onDrag(InventoryDragEvent event) {
+        UUID id = event.getWhoClicked().getUniqueId();
+        if (!viewers.contains(id)) return;
+        for (int slot : event.getRawSlots()) {
+            if (slot < event.getView().getTopInventory().getSize()) {
+                event.setCancelled(true);
+                break;
+            }
+        }
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- ensure hive collections run in a DB transaction and only issue items after commit
- check player inventory space before delivering items or starter bees
- block shift-click, number-key swaps, and dragging in hive-related GUIs

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8775ed394832aadfc8a5b763f065a