### PR TITLE
Allow configuring database file via config

### DIFF
--- a/src/main/java/org/maks/beesPlugin/BeesPlugin.java
+++ b/src/main/java/org/maks/beesPlugin/BeesPlugin.java
@@ -30,7 +30,11 @@ public final class BeesPlugin extends JavaPlugin {
         saveDefaultConfig();
         beesConfig = new BeesConfig(getConfig());
         try {
-            File dbFile = new File(getDataFolder(), "bees.db");
+            String dbPath = getConfig().getString("database.file", "bees.db");
+            File dbFile = new File(dbPath);
+            if (!dbFile.isAbsolute()) {
+                dbFile = new File(getDataFolder(), dbPath);
+            }
             database = new Database("jdbc:sqlite:" + dbFile.getAbsolutePath());
         } catch (SQLException e) {
             getLogger().severe("Failed to init database: " + e.getMessage());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,6 @@
+database:
+  file: bees.db
+
 bees:
   tick_seconds: 10
   unit_per_bottle: 60


### PR DESCRIPTION
## Summary
- Make database file path configurable through `config.yml`
- Load SQLite file from either absolute or plugin-data-relative path

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a888fa3a0c832aae9a00da1ebc05b3