### PR TITLE
Switch to MySQL configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,10 +83,10 @@
             <version>1.7</version>
             <scope>provided</scope>
         </dependency>
-            <dependency>
-            <groupId>org.xerial</groupId>
-            <artifactId>sqlite-jdbc</artifactId>
-            <version>3.44.1.0</version>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.33</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/maks/beesPlugin/BeesPlugin.java
+++ b/src/main/java/org/maks/beesPlugin/BeesPlugin.java
@@ -11,7 +11,6 @@ import org.maks.beesPlugin.gui.InfusionGui;
 import org.maks.beesPlugin.hive.HiveManager;
 import net.milkbowl.vault.economy.Economy;
 
-import java.io.File;
 import java.sql.SQLException;
 
 public final class BeesPlugin extends JavaPlugin {
@@ -30,8 +29,14 @@ public final class BeesPlugin extends JavaPlugin {
         saveDefaultConfig();
         beesConfig = new BeesConfig(getConfig());
         try {
-            File dbFile = new File(getDataFolder(), "bees.db");
-            database = new Database("jdbc:sqlite:" + dbFile.getAbsolutePath());
+            String host = getConfig().getString("database.host", "localhost");
+            String portStr = getConfig().getString("database.port", "3306");
+            int port = Integer.parseInt(portStr);
+            String dbName = getConfig().getString("database.name", "minecraft");
+            String user = getConfig().getString("database.user", "root");
+            String password = getConfig().getString("database.password", "");
+            String url = "jdbc:mysql://" + host + ":" + port + "/" + dbName + "?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC";
+            database = new Database(url, user, password);
         } catch (SQLException e) {
             getLogger().severe("Failed to init database: " + e.getMessage());
             return;

--- a/src/main/java/org/maks/beesPlugin/dao/Database.java
+++ b/src/main/java/org/maks/beesPlugin/dao/Database.java
@@ -4,52 +4,56 @@ import java.sql.*;
 import java.util.function.Consumer;
 
 /**
- * Simple wrapper around a JDBC connection to a SQLite database.
+ * Simple wrapper around a JDBC connection to a MySQL database.
  * Responsible for creating the schema and running small transactions.
  */
 public class Database {
     private final String url;
+    private final String user;
+    private final String password;
 
-    public Database(String url) throws SQLException {
+    public Database(String url, String user, String password) throws SQLException {
         this.url = url;
+        this.user = user;
+        this.password = password;
         init();
     }
 
     private void init() throws SQLException {
         try (Connection conn = getConnection(); Statement st = conn.createStatement()) {
             st.executeUpdate("CREATE TABLE IF NOT EXISTS players(" +
-                    "uuid TEXT PRIMARY KEY\n" +
-                    ")");
+                    "uuid VARCHAR(36) PRIMARY KEY" +
+                    ") ENGINE=InnoDB");
             st.executeUpdate("CREATE TABLE IF NOT EXISTS hives(" +
-                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
-                    "player_uuid TEXT NOT NULL," +
-                    "last_tick INTEGER NOT NULL," +
-                    "honey_i INTEGER NOT NULL DEFAULT 0," +
-                    "honey_ii INTEGER NOT NULL DEFAULT 0," +
-                    "honey_iii INTEGER NOT NULL DEFAULT 0," +
-                    "larvae_i INTEGER NOT NULL DEFAULT 0," +
-                    "larvae_ii INTEGER NOT NULL DEFAULT 0," +
-                    "larvae_iii INTEGER NOT NULL DEFAULT 0," +
-                    "queen INTEGER" +
-                    ")");
+                    "id INT AUTO_INCREMENT PRIMARY KEY," +
+                    "player_uuid VARCHAR(36) NOT NULL," +
+                    "last_tick BIGINT NOT NULL," +
+                    "honey_i INT NOT NULL DEFAULT 0," +
+                    "honey_ii INT NOT NULL DEFAULT 0," +
+                    "honey_iii INT NOT NULL DEFAULT 0," +
+                    "larvae_i INT NOT NULL DEFAULT 0," +
+                    "larvae_ii INT NOT NULL DEFAULT 0," +
+                    "larvae_iii INT NOT NULL DEFAULT 0," +
+                    "queen INT" +
+                    ") ENGINE=InnoDB");
             st.executeUpdate("CREATE TABLE IF NOT EXISTS hive_bees(" +
-                    "hive_id INTEGER NOT NULL," +
-                    "type TEXT NOT NULL," +
-                    "slot INTEGER NOT NULL," +
-                    "tier INTEGER NOT NULL" +
-                    ")");
+                    "hive_id INT NOT NULL," +
+                    "type VARCHAR(255) NOT NULL," +
+                    "slot INT NOT NULL," +
+                    "tier INT NOT NULL" +
+                    ") ENGINE=InnoDB");
             st.executeUpdate("CREATE TABLE IF NOT EXISTS bee_locker(" +
-                    "player_uuid TEXT NOT NULL," +
-                    "type TEXT NOT NULL," +
-                    "tier INTEGER NOT NULL," +
-                    "amount INTEGER NOT NULL," +
+                    "player_uuid VARCHAR(36) NOT NULL," +
+                    "type VARCHAR(255) NOT NULL," +
+                    "tier INT NOT NULL," +
+                    "amount INT NOT NULL," +
                     "PRIMARY KEY(player_uuid,type,tier)" +
-                    ")");
+                    ") ENGINE=InnoDB");
         }
     }
 
     public Connection getConnection() throws SQLException {
-        return DriverManager.getConnection(url);
+        return DriverManager.getConnection(url, user, password);
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,10 @@
+database:
+  host: "localhost"
+  port: "3306"
+  name: "minecraft"
+  user: "root"
+  password: ""
+
 bees:
   tick_seconds: 10
   unit_per_bottle: 60


### PR DESCRIPTION
## Summary
- Replace SQLite setup with MySQL connection details from config
- Initialize schema and connections using MySQL driver
- Swap sqlite dependency for mysql-connector-java in `pom.xml`
- Replace hardcoded credentials in `config.yml` with generic placeholders

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a888fa3a0c832aae9a00da1ebc05b3