### PR TITLE
fix: MySQL insert syntax for players and locker

### DIFF
--- a/src/main/java/org/maks/beesPlugin/dao/BeeLockerDao.java
+++ b/src/main/java/org/maks/beesPlugin/dao/BeeLockerDao.java
@@ -31,7 +31,9 @@ public class BeeLockerDao {
     }
 
     public void upsert(Connection conn, UUID player, BeeType type, Tier tier, int amount) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO bee_locker(player_uuid,type,tier,amount) VALUES (?,?,?,?) ON CONFLICT(player_uuid,type,tier) DO UPDATE SET amount=excluded.amount")) {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO bee_locker(player_uuid,type,tier,amount) VALUES (?,?,?,?) " +
+                "ON DUPLICATE KEY UPDATE amount=VALUES(amount)")) {
             ps.setString(1, player.toString());
             ps.setString(2, type.name());
             ps.setInt(3, tier.getLevel());

--- a/src/main/java/org/maks/beesPlugin/dao/PlayerDao.java
+++ b/src/main/java/org/maks/beesPlugin/dao/PlayerDao.java
@@ -13,7 +13,7 @@ public class PlayerDao {
 
     public void createPlayer(UUID uuid) throws SQLException {
         try (Connection conn = db.getConnection();
-             PreparedStatement ps = conn.prepareStatement("INSERT OR IGNORE INTO players(uuid) VALUES (?)")) {
+             PreparedStatement ps = conn.prepareStatement("INSERT IGNORE INTO players(uuid) VALUES (?)")) {
             ps.setString(1, uuid.toString());
             ps.executeUpdate();
         }


### PR DESCRIPTION
## Summary
- use `INSERT IGNORE` when creating players
- replace SQLite conflict clause with MySQL's `ON DUPLICATE KEY UPDATE`

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a88f645f68832a9e655595e6ab4a19