### PR TITLE
Prefix database table names with bees_

### DIFF
--- a/src/main/java/org/maks/beesPlugin/dao/BeeLockerDao.java
+++ b/src/main/java/org/maks/beesPlugin/dao/BeeLockerDao.java
@@ -8,7 +8,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.UUID;
 
-/** CRUD operations for the bee_locker table. */
+/** CRUD operations for the bees_locker table. */
 public class BeeLockerDao {
     private final Database db;
 
@@ -17,7 +17,7 @@ public class BeeLockerDao {
     }
 
     public Map<Tier, Integer> load(Connection conn, UUID player, BeeType type) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement("SELECT tier,amount FROM bee_locker WHERE player_uuid=? AND type=?")) {
+        try (PreparedStatement ps = conn.prepareStatement("SELECT tier,amount FROM bees_locker WHERE player_uuid=? AND type=?")) {
             ps.setString(1, player.toString());
             ps.setString(2, type.name());
             try (ResultSet rs = ps.executeQuery()) {
@@ -32,7 +32,7 @@ public class BeeLockerDao {
 
     public void upsert(Connection conn, UUID player, BeeType type, Tier tier, int amount) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(
-                "INSERT INTO bee_locker(player_uuid,type,tier,amount) VALUES (?,?,?,?) " +
+                "INSERT INTO bees_locker(player_uuid,type,tier,amount) VALUES (?,?,?,?) " +
                 "ON DUPLICATE KEY UPDATE amount=VALUES(amount)")) {
             ps.setString(1, player.toString());
             ps.setString(2, type.name());
@@ -43,7 +43,7 @@ public class BeeLockerDao {
     }
 
     public void delete(Connection conn, UUID player) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement("DELETE FROM bee_locker WHERE player_uuid=?")) {
+        try (PreparedStatement ps = conn.prepareStatement("DELETE FROM bees_locker WHERE player_uuid=?")) {
             ps.setString(1, player.toString());
             ps.executeUpdate();
         }

--- a/src/main/java/org/maks/beesPlugin/dao/Database.java
+++ b/src/main/java/org/maks/beesPlugin/dao/Database.java
@@ -21,10 +21,10 @@ public class Database {
 
     private void init() throws SQLException {
         try (Connection conn = getConnection(); Statement st = conn.createStatement()) {
-            st.executeUpdate("CREATE TABLE IF NOT EXISTS players(" +
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS bees_players(" +
                     "uuid VARCHAR(36) PRIMARY KEY" +
                     ") ENGINE=InnoDB");
-            st.executeUpdate("CREATE TABLE IF NOT EXISTS hives(" +
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS bees_hives(" +
                     "id INT AUTO_INCREMENT PRIMARY KEY," +
                     "player_uuid VARCHAR(36) NOT NULL," +
                     "last_tick BIGINT NOT NULL," +
@@ -36,13 +36,13 @@ public class Database {
                     "larvae_iii INT NOT NULL DEFAULT 0," +
                     "queen INT" +
                     ") ENGINE=InnoDB");
-            st.executeUpdate("CREATE TABLE IF NOT EXISTS hive_bees(" +
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS bees_hive_bees(" +
                     "hive_id INT NOT NULL," +
                     "type VARCHAR(255) NOT NULL," +
                     "slot INT NOT NULL," +
                     "tier INT NOT NULL" +
                     ") ENGINE=InnoDB");
-            st.executeUpdate("CREATE TABLE IF NOT EXISTS bee_locker(" +
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS bees_locker(" +
                     "player_uuid VARCHAR(36) NOT NULL," +
                     "type VARCHAR(255) NOT NULL," +
                     "tier INT NOT NULL," +

--- a/src/main/java/org/maks/beesPlugin/dao/HiveBeeDao.java
+++ b/src/main/java/org/maks/beesPlugin/dao/HiveBeeDao.java
@@ -7,7 +7,7 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
-/** CRUD access to the hive_bees table. */
+/** CRUD access to the bees_hive_bees table. */
 public class HiveBeeDao {
     private final Database db;
 
@@ -16,7 +16,7 @@ public class HiveBeeDao {
     }
 
     public List<Tier> loadBees(Connection conn, int hiveId, BeeType type) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement("SELECT tier FROM hive_bees WHERE hive_id=? AND type=? ORDER BY slot")) {
+        try (PreparedStatement ps = conn.prepareStatement("SELECT tier FROM bees_hive_bees WHERE hive_id=? AND type=? ORDER BY slot")) {
             ps.setInt(1, hiveId);
             ps.setString(2, type.name());
             try (ResultSet rs = ps.executeQuery()) {
@@ -30,12 +30,12 @@ public class HiveBeeDao {
     }
 
     public void replaceBees(Connection conn, int hiveId, BeeType type, List<Tier> bees) throws SQLException {
-        try (PreparedStatement del = conn.prepareStatement("DELETE FROM hive_bees WHERE hive_id=? AND type=?")) {
+        try (PreparedStatement del = conn.prepareStatement("DELETE FROM bees_hive_bees WHERE hive_id=? AND type=?")) {
             del.setInt(1, hiveId);
             del.setString(2, type.name());
             del.executeUpdate();
         }
-        try (PreparedStatement ins = conn.prepareStatement("INSERT INTO hive_bees(hive_id,type,slot,tier) VALUES (?,?,?,?)")) {
+        try (PreparedStatement ins = conn.prepareStatement("INSERT INTO bees_hive_bees(hive_id,type,slot,tier) VALUES (?,?,?,?)")) {
             int slot = 0;
             for (Tier t : bees) {
                 ins.setInt(1, hiveId);

--- a/src/main/java/org/maks/beesPlugin/dao/HiveDao.java
+++ b/src/main/java/org/maks/beesPlugin/dao/HiveDao.java
@@ -8,7 +8,7 @@ import java.sql.*;
 import java.util.*;
 import java.util.UUID;
 
-/** DAO encapsulating CRUD operations for hives and hive_bees. */
+/** DAO encapsulating CRUD operations for bees_hives and bees_hive_bees. */
 public class HiveDao {
     private final Database db;
     private final HiveBeeDao beeDao;
@@ -21,7 +21,7 @@ public class HiveDao {
     public List<Hive> loadHives(UUID player, long now) throws SQLException {
         List<Hive> list = new ArrayList<>();
         try (Connection conn = db.getConnection();
-             PreparedStatement ps = conn.prepareStatement("SELECT id,last_tick,queen,honey_i,honey_ii,honey_iii,larvae_i,larvae_ii,larvae_iii FROM hives WHERE player_uuid=?")) {
+             PreparedStatement ps = conn.prepareStatement("SELECT id,last_tick,queen,honey_i,honey_ii,honey_iii,larvae_i,larvae_ii,larvae_iii FROM bees_hives WHERE player_uuid=?")) {
             ps.setString(1, player.toString());
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
@@ -48,7 +48,7 @@ public class HiveDao {
 
     public int createHive(Connection conn, UUID player, Hive hive) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(
-                "INSERT INTO hives(player_uuid,last_tick,queen) VALUES (?,?,?)",
+                "INSERT INTO bees_hives(player_uuid,last_tick,queen) VALUES (?,?,?)",
                 Statement.RETURN_GENERATED_KEYS)) {
             ps.setString(1, player.toString());
             ps.setLong(2, hive.getLastTick());
@@ -66,7 +66,7 @@ public class HiveDao {
     }
 
     public void updateHive(Connection conn, UUID player, Hive hive) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement("UPDATE hives SET last_tick=?,queen=?,honey_i=?,honey_ii=?,honey_iii=?,larvae_i=?,larvae_ii=?,larvae_iii=? WHERE id=? AND player_uuid=?")) {
+        try (PreparedStatement ps = conn.prepareStatement("UPDATE bees_hives SET last_tick=?,queen=?,honey_i=?,honey_ii=?,honey_iii=?,larvae_i=?,larvae_ii=?,larvae_iii=? WHERE id=? AND player_uuid=?")) {
             ps.setLong(1, hive.getLastTick());
             if (hive.getQueen() == null) ps.setNull(2, Types.INTEGER); else ps.setInt(2, hive.getQueen().getLevel());
             ps.setInt(3, hive.getHoneyStored().get(Tier.I));
@@ -84,11 +84,11 @@ public class HiveDao {
     }
 
     public void deleteHive(Connection conn, int id) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement("DELETE FROM hives WHERE id=?")) {
+        try (PreparedStatement ps = conn.prepareStatement("DELETE FROM bees_hives WHERE id=?")) {
             ps.setInt(1, id);
             ps.executeUpdate();
         }
-        try (PreparedStatement ps = conn.prepareStatement("DELETE FROM hive_bees WHERE hive_id=?")) {
+        try (PreparedStatement ps = conn.prepareStatement("DELETE FROM bees_hive_bees WHERE hive_id=?")) {
             ps.setInt(1, id);
             ps.executeUpdate();
         }

--- a/src/main/java/org/maks/beesPlugin/dao/PlayerDao.java
+++ b/src/main/java/org/maks/beesPlugin/dao/PlayerDao.java
@@ -3,7 +3,7 @@ package org.maks.beesPlugin.dao;
 import java.sql.*;
 import java.util.UUID;
 
-/** DAO for operations on the players table. */
+/** DAO for operations on the bees_players table. */
 public class PlayerDao {
     private final Database db;
 
@@ -13,7 +13,7 @@ public class PlayerDao {
 
     public void createPlayer(UUID uuid) throws SQLException {
         try (Connection conn = db.getConnection();
-             PreparedStatement ps = conn.prepareStatement("INSERT IGNORE INTO players(uuid) VALUES (?)")) {
+             PreparedStatement ps = conn.prepareStatement("INSERT IGNORE INTO bees_players(uuid) VALUES (?)")) {
             ps.setString(1, uuid.toString());
             ps.executeUpdate();
         }
@@ -21,7 +21,7 @@ public class PlayerDao {
 
     public void deletePlayer(UUID uuid) throws SQLException {
         try (Connection conn = db.getConnection();
-             PreparedStatement ps = conn.prepareStatement("DELETE FROM players WHERE uuid = ?")) {
+             PreparedStatement ps = conn.prepareStatement("DELETE FROM bees_players WHERE uuid = ?")) {
             ps.setString(1, uuid.toString());
             ps.executeUpdate();
         }
@@ -29,7 +29,7 @@ public class PlayerDao {
 
     public boolean exists(UUID uuid) throws SQLException {
         try (Connection conn = db.getConnection();
-             PreparedStatement ps = conn.prepareStatement("SELECT 1 FROM players WHERE uuid = ?")) {
+             PreparedStatement ps = conn.prepareStatement("SELECT 1 FROM bees_players WHERE uuid = ?")) {
             ps.setString(1, uuid.toString());
             try (ResultSet rs = ps.executeQuery()) {
                 return rs.next();


### PR DESCRIPTION
## Summary
- rename generic tables to bees_players, bees_hives, bees_hive_bees, bees_locker
- update DAOs to use new prefixed table names

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b5344df4832a9d4df98feb177ca1