### PR TITLE
Use beesplugin permission node

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,5 +5,5 @@ api-version: '1.20'
 commands:
   hive:
     description: Manage hives
-    permission: mycraftingplugin.use
+    permission: beesplugin.hive
     usage: /hive


### PR DESCRIPTION
## Summary
- replace generic permission node with plugin-specific `beesplugin.hive`

## Testing
- `mvn -Djava.net.preferIPv4Stack=true package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a986d76084832aa15a031d7523d1bd