### PR TITLE
Disable plugin when database initialization fails

### DIFF
--- a/src/main/java/org/maks/beesPlugin/BeesPlugin.java
+++ b/src/main/java/org/maks/beesPlugin/BeesPlugin.java
@@ -39,6 +39,7 @@ public final class BeesPlugin extends JavaPlugin {
             database = new Database(url, user, password);
         } catch (SQLException e) {
             getLogger().severe("Failed to init database: " + e.getMessage());
+            getServer().getPluginManager().disablePlugin(this);
             return;
         }
         HiveBeeDao hiveBeeDao = new HiveBeeDao(database);


### PR DESCRIPTION
## Summary
- Disable BeesPlugin if database initialization fails during startup

## Testing
- `mvn -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a9876858e0832ab67e274983ecaa37