### PR TITLE
Add MySQL Connector/J dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,5 +74,10 @@
             <version>1.7</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- include MySQL Connector/J so the plugin can reach MySQL databases

## Testing
- `mvn package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central https://repo.maven.apache.org/maven2: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a987f66998832ab16fa551eff37ed7