### PR TITLE
Fix Vault detection for economy

### DIFF
--- a/src/main/java/org/maks/beesPlugin/BeesPlugin.java
+++ b/src/main/java/org/maks/beesPlugin/BeesPlugin.java
@@ -67,14 +67,16 @@ public final class BeesPlugin extends JavaPlugin {
     }
 
     private void setupEconomy() {
-        try {
-            RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
-            if (rsp != null) {
-                economy = rsp.getProvider();
-            }
-        } catch (NoClassDefFoundError e) {
+        if (getServer().getPluginManager().getPlugin("Vault") == null) {
             getLogger().warning("Vault not found, economy disabled");
+            return;
         }
+        RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
+        if (rsp == null) {
+            getLogger().warning("No economy provider found, economy disabled");
+            return;
+        }
+        economy = rsp.getProvider();
     }
 
     @Override

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: beesPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.beesPlugin.BeesPlugin
 api-version: '1.20'
+softdepend: [Vault]
 commands:
   hive:
     description: Manage hives


### PR DESCRIPTION
## Summary
- ensure Vault is soft dependency
- properly initialize Vault economy provider with plugin presence and provider checks

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a98b1b195c832ab4b7e1dcced9b73d