### PR TITLE
Refine hive GUI and larva infusion flow

### DIFF
--- a/src/main/java/org/maks/beesPlugin/gui/HiveMenuGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/HiveMenuGui.java
@@ -101,8 +101,9 @@ public class HiveMenuGui implements Listener {
                         return;
                     }
                 }
+                boolean firstHive = list.isEmpty();
                 Hive hive = hiveManager.createHive(id, System.currentTimeMillis() / 1000);
-                if (hive != null && list.isEmpty()) {
+                if (hive != null && firstHive) {
                     var starters = List.of(
                             BeeItems.createBee(BeeType.QUEEN, Tier.I),
                             BeeItems.createBee(BeeType.WORKER, Tier.I),

--- a/src/main/java/org/maks/beesPlugin/gui/InfusionGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/InfusionGui.java
@@ -6,11 +6,11 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
-import org.bukkit.event.inventory.ClickType;
-import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -37,12 +37,13 @@ public class InfusionGui implements Listener {
         for (int i = 0; i < inv.getSize(); i++) {
             inv.setItem(i, filler);
         }
-        ItemStack larvaPlaceholder = createPane(Material.WHITE_STAINED_GLASS_PANE, ChatColor.GRAY + "Larva");
-        ItemStack honeyPlaceholder = createPane(Material.ORANGE_STAINED_GLASS_PANE, ChatColor.GRAY + "Honey");
-        for (int slot : HONEY_SLOTS) {
-            inv.setItem(slot, honeyPlaceholder);
-        }
-        inv.setItem(LARVA_SLOT, larvaPlaceholder);
+        inv.setItem(HONEY_SLOT, createPane(Material.ORANGE_STAINED_GLASS_PANE, ChatColor.GRAY + "Honey"));
+        inv.setItem(LARVA_SLOT, createPane(Material.WHITE_STAINED_GLASS_PANE, ChatColor.GRAY + "Larva"));
+        ItemStack button = new ItemStack(Material.ANVIL);
+        ItemMeta bm = button.getItemMeta();
+        bm.setDisplayName(ChatColor.AQUA + "Infuse");
+        button.setItemMeta(bm);
+        inv.setItem(INFUSE_SLOT, button);
         viewers.add(player.getUniqueId());
         player.openInventory(inv);
     }
@@ -67,7 +68,7 @@ public class InfusionGui implements Listener {
                     event.setCancelled(true);
                     return;
                 }
-            } else if (isHoneySlot(raw)) {
+            } else if (raw == HONEY_SLOT) {
                 ItemStack cursor = event.getCursor();
                 ItemStack current = event.getCurrentItem();
                 if (cursor != null && !cursor.getType().isAir()) {
@@ -80,14 +81,63 @@ public class InfusionGui implements Listener {
                     event.setCancelled(true);
                     return;
                 }
+            } else if (raw == INFUSE_SLOT) {
+                event.setCancelled(true);
+                Player player = (Player) event.getWhoClicked();
+                Inventory inv = top;
+                ItemStack larvaStack = inv.getItem(LARVA_SLOT);
+                ItemStack honeyStack = inv.getItem(HONEY_SLOT);
+                BeeItems.BeeItem larva = BeeItems.parse(larvaStack);
+                Tier honeyTier = BeeItems.parseHoney(honeyStack);
+                if (larva == null || larva.type() != BeeType.LARVA || larvaStack.getAmount() != 1 || honeyTier == null) {
+                    player.sendMessage(ChatColor.RED + "Insert one larva and one honey bottle");
+                    return;
+                }
+                BeesConfig.InfusionCost cost = config.infusionCost.get(larva.tier());
+                int required = switch (honeyTier) {
+                    case I -> cost.honeyI();
+                    case II -> cost.honeyII();
+                    case III -> cost.honeyIII();
+                };
+                if (honeyStack.getAmount() < required) {
+                    player.sendMessage(ChatColor.RED + "Not enough honey");
+                    return;
+                }
+                honeyStack.setAmount(honeyStack.getAmount() - required);
+                if (honeyStack.getAmount() > 0) {
+                    inv.setItem(HONEY_SLOT, honeyStack);
+                } else {
+                    inv.setItem(HONEY_SLOT, createPane(Material.ORANGE_STAINED_GLASS_PANE, ChatColor.GRAY + "Honey"));
+                }
+                inv.setItem(LARVA_SLOT, createPane(Material.WHITE_STAINED_GLASS_PANE, ChatColor.GRAY + "Larva"));
+                performInfusion(player, larva.tier());
             } else {
                 event.setCancelled(true);
                 return;
             }
             if (event.isShiftClick() || event.getClick() == ClickType.NUMBER_KEY ||
-                    event.getAction() == InventoryAction.COLLECT_TO_CURSOR) {
+                    event.getAction() == InventoryAction.COLLECT_TO_CURSOR ||
+                    event.getAction().name().contains("DROP")) {
                 event.setCancelled(true);
             }
+        } else {
+            if (event.isShiftClick()) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    private void performInfusion(Player player, Tier larvaTier) {
+        Map<BeeType, Double> weights = config.infusionTypeWeights.get(larvaTier);
+        BeeType resultType = rollType(weights);
+        BeesConfig.TierShift shift = config.infusionTierShift.get(larvaTier);
+        int tierShift = rollTierShift(shift);
+        int newLevel = Math.min(3, Math.max(1, larvaTier.getLevel() + tierShift));
+        Tier resultTier = Tier.fromLevel(newLevel);
+        ItemStack bee = BeeItems.createBee(resultType, resultTier);
+        Map<Integer, ItemStack> left = player.getInventory().addItem(bee);
+        for (ItemStack s : left.values()) {
+            player.getWorld().dropItem(player.getLocation(), s);
         }
     }
 
@@ -107,84 +157,15 @@ public class InfusionGui implements Listener {
     public void onClose(InventoryCloseEvent event) {
         UUID id = event.getPlayer().getUniqueId();
         if (!viewers.remove(id)) return;
-
         Player player = (Player) event.getPlayer();
         Inventory inv = event.getInventory();
+        returnItem(player, inv.getItem(LARVA_SLOT));
+        returnItem(player, inv.getItem(HONEY_SLOT));
+    }
 
-        ItemStack larvaStack = inv.getItem(LARVA_SLOT);
-        BeeItems.BeeItem larva = BeeItems.parse(larvaStack);
-        if (larva == null || larva.type() != BeeType.LARVA || larvaStack.getAmount() != 1) {
-            returnItems(player, inv.getContents());
-            player.sendMessage(ChatColor.RED + "Place exactly one larva in the middle.");
-            return;
-        }
-        Tier larvaTier = larva.tier();
-        BeesConfig.InfusionCost cost = config.infusionCost.get(larvaTier);
-        if (cost == null) {
-            returnItems(player, inv.getContents());
-            return;
-        }
-
-        EnumMap<Tier, Integer> honeyCounts = new EnumMap<>(Tier.class);
-        boolean invalid = false;
-        for (int i = 0; i < inv.getSize(); i++) {
-            if (i == LARVA_SLOT) continue;
-            ItemStack stack = inv.getItem(i);
-            if (stack == null) continue;
-            Tier t = BeeItems.parseHoney(stack);
-            if (t == null) {
-                invalid = true;
-                break;
-            }
-            honeyCounts.merge(t, stack.getAmount(), Integer::sum);
-        }
-        if (invalid) {
-            returnItems(player, inv.getContents());
-            player.sendMessage(ChatColor.RED + "Only honey bottles around the larva are allowed.");
-            return;
-        }
-
-        if (honeyCounts.getOrDefault(Tier.I, 0) < cost.honeyI() ||
-            honeyCounts.getOrDefault(Tier.II, 0) < cost.honeyII() ||
-            honeyCounts.getOrDefault(Tier.III, 0) < cost.honeyIII()) {
-            returnItems(player, inv.getContents());
-            player.sendMessage(ChatColor.RED + "Not enough honey for infusion.");
-            return;
-        }
-
-        // return excess honey
-        int excessI = honeyCounts.getOrDefault(Tier.I, 0) - cost.honeyI();
-        int excessII = honeyCounts.getOrDefault(Tier.II, 0) - cost.honeyII();
-        int excessIII = honeyCounts.getOrDefault(Tier.III, 0) - cost.honeyIII();
-        List<ItemStack> extras = new ArrayList<>();
-        if (excessI > 0) {
-            ItemStack hi = BeeItems.createHoney(Tier.I);
-            hi.setAmount(excessI);
-            extras.add(hi);
-        }
-        if (excessII > 0) {
-            ItemStack hi = BeeItems.createHoney(Tier.II);
-            hi.setAmount(excessII);
-            extras.add(hi);
-        }
-        if (excessIII > 0) {
-            ItemStack hi = BeeItems.createHoney(Tier.III);
-            hi.setAmount(excessIII);
-            extras.add(hi);
-        }
-        returnItems(player, extras.toArray(new ItemStack[0]));
-
-        // determine bee type
-        Map<BeeType, Double> weights = config.infusionTypeWeights.get(larvaTier);
-        BeeType resultType = rollType(weights);
-
-        BeesConfig.TierShift shift = config.infusionTierShift.get(larvaTier);
-        int tierShift = rollTierShift(shift);
-        int newLevel = Math.min(3, Math.max(1, larvaTier.getLevel() + tierShift));
-        Tier resultTier = Tier.fromLevel(newLevel);
-
-        ItemStack bee = BeeItems.createBee(resultType, resultTier);
-        Map<Integer, ItemStack> left = player.getInventory().addItem(bee);
+    private void returnItem(Player player, ItemStack stack) {
+        if (stack == null || stack.getType().isAir() || stack.getType().toString().endsWith("GLASS_PANE")) return;
+        Map<Integer, ItemStack> left = player.getInventory().addItem(stack);
         for (ItemStack s : left.values()) {
             player.getWorld().dropItem(player.getLocation(), s);
         }
@@ -212,24 +193,6 @@ public class InfusionGui implements Listener {
         return 2;
     }
 
-    private void returnItems(Player player, ItemStack[] items) {
-        for (ItemStack stack : items) {
-            if (stack == null || stack.getType().isAir() || stack.getType().toString().endsWith("GLASS_PANE")) continue;
-            Map<Integer, ItemStack> left = player.getInventory().addItem(stack);
-            for (ItemStack s : left.values()) {
-                player.getWorld().dropItem(player.getLocation(), s);
-            }
-        }
-    }
-
-    private static final int LARVA_SLOT = 4;
-    private static final int[] HONEY_SLOTS = {0,1,2,3,5,6,7,8};
-
-    private boolean isHoneySlot(int slot) {
-        for (int s : HONEY_SLOTS) if (slot == s) return true;
-        return false;
-    }
-
     private ItemStack createPane(Material material, String name) {
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
@@ -237,4 +200,9 @@ public class InfusionGui implements Listener {
         item.setItemMeta(meta);
         return item;
     }
+
+    private static final int HONEY_SLOT = 3;
+    private static final int LARVA_SLOT = 5;
+    private static final int INFUSE_SLOT = 4;
 }
+

--- a/src/main/java/org/maks/beesPlugin/item/BeeItems.java
+++ b/src/main/java/org/maks/beesPlugin/item/BeeItems.java
@@ -1,5 +1,6 @@
 package org.maks.beesPlugin.item;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
@@ -15,17 +16,33 @@ import java.util.regex.Pattern;
 public class BeeItems {
 
     public static ItemStack createHoney(Tier tier) {
-        ItemStack item = new ItemStack(Material.HONEYCOMB);
+        ItemStack item = new ItemStack(Material.HONEY_BOTTLE);
         ItemMeta meta = item.getItemMeta();
         meta.addEnchant(Enchantment.DURABILITY, 10, true);
-        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES);
+        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
         String color = switch (tier) {
-            case I -> "§9";
-            case II -> "§5";
-            case III -> "§6";
+            case I -> ChatColor.BLUE.toString();
+            case II -> ChatColor.DARK_PURPLE.toString();
+            case III -> ChatColor.GOLD.toString();
         };
-        meta.setDisplayName(color + "[ " + tier.getLevel() + " ] Honey Comb");
-        meta.setLore(List.of("§o§7Applies a new §fQuality§7 to an item."));
+        meta.setDisplayName(color + "[ " + tier.name() + " ] Honey Bottle");
+        List<String> lore = new java.util.ArrayList<>();
+        lore.add(ChatColor.ITALIC + "" + ChatColor.GRAY + "Applies a new " + ChatColor.WHITE + "Quality" + ChatColor.GRAY + " to an item.");
+        switch (tier) {
+            case I -> lore.addAll(List.of(
+                    ChatColor.ITALIC + "" + ChatColor.GRAY + "Roll range: " + ChatColor.WHITE + "-10% " + ChatColor.GRAY + "to " + ChatColor.WHITE + "+10%.",
+                    ChatColor.ITALIC + "" + ChatColor.GRAY + "Basic crafting material"
+            ));
+            case II -> lore.addAll(List.of(
+                    ChatColor.ITALIC + "" + ChatColor.GRAY + "Roll range: " + ChatColor.WHITE + "0% " + ChatColor.GRAY + "to " + ChatColor.WHITE + "+20%.",
+                    ChatColor.ITALIC + "" + ChatColor.GRAY + ChatColor.GREEN + "Rare" + ChatColor.GRAY + " crafting material"
+            ));
+            case III -> lore.addAll(List.of(
+                    ChatColor.ITALIC + "" + ChatColor.GRAY + "Roll range: " + ChatColor.WHITE + "+10% " + ChatColor.GRAY + "to " + ChatColor.WHITE + "+30%.",
+                    ChatColor.ITALIC + "" + ChatColor.GRAY + ChatColor.RED + "Legendary" + ChatColor.GRAY + " crafting material"
+            ));
+        }
+        meta.setLore(lore);
         meta.setUnbreakable(true);
         item.setItemMeta(meta);
         return item;
@@ -34,24 +51,67 @@ public class BeeItems {
     public static ItemStack createBee(BeeType type, Tier tier) {
         Material material = switch (type) {
             case WORKER, QUEEN, DRONE -> Material.BREAD;
-            case LARVA -> Material.SLIME_BALL;
+            case LARVA -> Material.COOKIE;
         };
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
         meta.addEnchant(Enchantment.DURABILITY, 10, true);
-        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES);
+        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
         String color = switch (tier) {
-            case I -> "§9";
-            case II -> "§5";
-            case III -> "§6";
+            case I -> ChatColor.BLUE.toString();
+            case II -> ChatColor.DARK_PURPLE.toString();
+            case III -> ChatColor.GOLD.toString();
         };
-        String name = color + "[ " + tier.getLevel() + " ] " + switch (type) {
+        String name = color + "[ " + tier.name() + " ] " + switch (type) {
             case WORKER -> "Worker Bee";
             case DRONE -> "Drone Bee";
             case QUEEN -> "Queen Bee";
             case LARVA -> "Bee Larva";
         };
-        meta.setDisplayName(name);
+        List<String> lore = switch (type) {
+            case QUEEN -> {
+                String mult = switch (tier) {
+                    case I -> "1.0x";
+                    case II -> "1.2x";
+                    case III -> "1.5x";
+                };
+                String chance = switch (tier) {
+                    case I -> "+5%";
+                    case II -> "+10%";
+                    case III -> "+15%";
+                };
+                yield List.of(
+                        ChatColor.ITALIC + "" + ChatColor.GRAY + "Hive multiplier: " + ChatColor.WHITE + mult,
+                        ChatColor.ITALIC + "" + ChatColor.GRAY + "Rarer honey chance: " + ChatColor.GREEN + chance
+                );
+            }
+            case WORKER -> {
+                String prod = switch (tier) {
+                    case I -> "0.50";
+                    case II -> "0.75";
+                    case III -> "1.00";
+                };
+                yield List.of(ChatColor.ITALIC + "" + ChatColor.GRAY + "Base honey production: " + ChatColor.WHITE + prod);
+            }
+            case DRONE -> {
+                String larvae = switch (tier) {
+                    case I -> "0.50";
+                    case II -> "0.75";
+                    case III -> "1.00";
+                };
+                String penalty = switch (tier) {
+                    case I -> "-1.00";
+                    case II -> "-0.75";
+                    case III -> "-0.50";
+                };
+                yield List.of(
+                        ChatColor.ITALIC + "" + ChatColor.GRAY + "Larvae production: " + ChatColor.WHITE + larvae,
+                        ChatColor.ITALIC + "" + ChatColor.GRAY + "Reduces base honey production: " + ChatColor.WHITE + penalty
+                );
+            }
+            case LARVA -> List.of(ChatColor.ITALIC + "" + ChatColor.GRAY + "Can transform into any type of bee.");
+        };
+        meta.setLore(lore);
         meta.setUnbreakable(true);
         item.setItemMeta(meta);
         return item;
@@ -59,24 +119,28 @@ public class BeeItems {
 
     public record BeeItem(BeeType type, Tier tier) {}
 
-    private static final Pattern NAME_PATTERN = Pattern.compile("\\[ (\\d) \\] (.+)");
+    private static final Pattern NAME_PATTERN = Pattern.compile("\\[ ([^\\]]+) \\] (.+)");
 
     public static BeeItem parse(ItemStack item) {
         if (item == null) return null;
         Material type = item.getType();
-        if (type != Material.BREAD && type != Material.SLIME_BALL) return null;
+        if (type != Material.BREAD && type != Material.COOKIE) return null;
         ItemMeta meta = item.getItemMeta();
         if (meta == null || !meta.hasDisplayName()) return null;
         String stripped = meta.getDisplayName().replaceAll("§[0-9a-fk-or]", "");
         Matcher m = NAME_PATTERN.matcher(stripped);
         if (!m.find()) return null;
-        int level;
+        String token = m.group(1);
+        Tier tier;
         try {
-            level = Integer.parseInt(m.group(1));
+            tier = Tier.fromLevel(Integer.parseInt(token));
         } catch (NumberFormatException e) {
-            return null;
+            try {
+                tier = Tier.valueOf(token);
+            } catch (IllegalArgumentException ex) {
+                return null;
+            }
         }
-        Tier tier = Tier.fromLevel(level);
         String name = m.group(2).toLowerCase();
         BeeType beeType;
         if (name.contains("queen")) beeType = BeeType.QUEEN;
@@ -88,18 +152,21 @@ public class BeeItems {
     }
 
     public static Tier parseHoney(ItemStack item) {
-        if (item == null || item.getType() != Material.HONEYCOMB) return null;
+        if (item == null || item.getType() != Material.HONEY_BOTTLE) return null;
         ItemMeta meta = item.getItemMeta();
         if (meta == null || !meta.hasDisplayName()) return null;
         String stripped = meta.getDisplayName().replaceAll("§[0-9a-fk-or]", "");
         Matcher m = NAME_PATTERN.matcher(stripped);
         if (!m.find()) return null;
-        int level;
+        String token = m.group(1);
         try {
-            level = Integer.parseInt(m.group(1));
+            return Tier.fromLevel(Integer.parseInt(token));
         } catch (NumberFormatException e) {
-            return null;
+            try {
+                return Tier.valueOf(token);
+            } catch (IllegalArgumentException ex) {
+                return null;
+            }
         }
-        return Tier.fromLevel(level);
     }
 }


### PR DESCRIPTION
## Summary
- Use ChatColor formatting so starter bees and honey bottles retain names and lore
- Center hive resource layout and fold tier chances into honey and larva rate items
- Simplify larva infusion to two input slots and an Infuse button that consumes honey cost

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a99956c08c832a8f6a48387c5f43d4