### PR TITLE
Restrict /hive command to high-level players

### DIFF
--- a/src/main/java/org/maks/beesPlugin/command/HiveCommand.java
+++ b/src/main/java/org/maks/beesPlugin/command/HiveCommand.java
@@ -1,5 +1,6 @@
 package org.maks.beesPlugin.command;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -20,6 +21,12 @@ public class HiveCommand implements CommandExecutor {
             sender.sendMessage("Only players");
             return true;
         }
+
+        if (player.getLevel() < 75) {
+            player.sendMessage(ChatColor.RED + "You must be at least level 80!");
+            return true;
+        }
+
         menu.open(player);
         return true;
     }


### PR DESCRIPTION
## Summary
- require players to reach level 75 before opening the hive menu
- show a red warning "You must be at least level 80!" if below the requirement

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b0635b5c832a94a6c2c1854fb988