### PR TITLE
Fix infusion GUI exploits and rebalance larva generation

### DIFF
--- a/src/main/java/org/maks/beesPlugin/gui/InfusionGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/InfusionGui.java
@@ -116,7 +116,7 @@ public class InfusionGui implements Listener {
                 performInfusion(player, larva.tier());
             }
         } else {
-            if (event.isShiftClick()) {
+            if (event.isShiftClick() || event.getAction() == org.bukkit.event.inventory.InventoryAction.COLLECT_TO_CURSOR) {
                 event.setCancelled(true);
             }
         }
@@ -151,7 +151,23 @@ public class InfusionGui implements Listener {
     @EventHandler
     public void onClose(InventoryCloseEvent event) {
         UUID id = event.getPlayer().getUniqueId();
-        viewers.remove(id);
+        if (!viewers.remove(id)) return;
+        Inventory inv = event.getInventory();
+        Player player = (Player) event.getPlayer();
+        ItemStack honey = inv.getItem(HONEY_SLOT);
+        if (honey != null && !honey.getType().toString().endsWith("GLASS_PANE")) {
+            Map<Integer, ItemStack> left = player.getInventory().addItem(honey);
+            for (ItemStack s : left.values()) {
+                player.getWorld().dropItem(player.getLocation(), s);
+            }
+        }
+        ItemStack larva = inv.getItem(LARVA_SLOT);
+        if (larva != null && !larva.getType().toString().endsWith("GLASS_PANE")) {
+            Map<Integer, ItemStack> left = player.getInventory().addItem(larva);
+            for (ItemStack s : left.values()) {
+                player.getWorld().dropItem(player.getLocation(), s);
+            }
+        }
     }
 
     private BeeType rollType(Map<BeeType, Double> weights) {

--- a/src/main/java/org/maks/beesPlugin/hive/Hive.java
+++ b/src/main/java/org/maks/beesPlugin/hive/Hive.java
@@ -158,7 +158,19 @@ public class Hive {
             DroneConfig dc = cfg.drones.get(t);
             cut += dc.honeyPenaltyPerTick();
             larvae += dc.larvaePerTick();
-            larvaeWeights.merge(t, dc.larvaePerTick(), Double::sum);
+            double w = dc.larvaePerTick();
+            switch (t) {
+                case I -> larvaeWeights.merge(Tier.I, w, Double::sum);
+                case II -> {
+                    larvaeWeights.merge(Tier.I, w * 0.25, Double::sum);
+                    larvaeWeights.merge(Tier.II, w * 0.75, Double::sum);
+                }
+                case III -> {
+                    larvaeWeights.merge(Tier.I, w * 0.10, Double::sum);
+                    larvaeWeights.merge(Tier.II, w * 0.30, Double::sum);
+                    larvaeWeights.merge(Tier.III, w * 0.60, Double::sum);
+                }
+            }
         }
         double net = Math.max(0, base - cut) * qc.multiplier();
         double larv = larvae * qc.multiplier();


### PR DESCRIPTION
## Summary
- prevent removing items from the Infusion GUI by cancelling collect-to-cursor actions and returning items on close
- rebalance larva tier generation so higher-tier drones increase odds for better larvae without guaranteeing tier III

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b5d6b1f0832aadd5900c9cb9ecd9