### PR TITLE
Refine larva and infusion mechanics

### DIFF
--- a/src/main/java/org/maks/beesPlugin/config/BeesConfig.java
+++ b/src/main/java/org/maks/beesPlugin/config/BeesConfig.java
@@ -11,6 +11,7 @@ import java.util.Map;
 public class BeesConfig {
     public final int tickSeconds;
     public final double unitPerBottle;
+    public final double unitPerLarva;
     public final int offlineCapHours;
 
     public final double baseRare;
@@ -39,6 +40,7 @@ public class BeesConfig {
         ConfigurationSection bees = config.getConfigurationSection("bees");
         tickSeconds = bees.getInt("tick_seconds", 10);
         unitPerBottle = bees.getDouble("unit_per_bottle", 60.0);
+        unitPerLarva = bees.getDouble("unit_per_larva", 60.0);
         offlineCapHours = bees.getInt("offline_cap_hours", 8);
 
         ConfigurationSection rarity = bees.getConfigurationSection("rarity");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,7 @@ database:
 bees:
   tick_seconds: 10
   unit_per_bottle: 60
+  unit_per_larva: 60
   offline_cap_hours: 8
 
   rarity:


### PR DESCRIPTION
## Summary
- bias larva generation toward Tier I and weight higher tiers by drone level
- scale infusion results with honey tier, removing honey cost scaling
- gate larva output behind configurable unit cost

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bb044ebc832aa963fd113c6be33a