### PR TITLE
Guard against replacing bees in hive slots

### DIFF
--- a/src/main/java/org/maks/beesPlugin/gui/HiveGui.java
+++ b/src/main/java/org/maks/beesPlugin/gui/HiveGui.java
@@ -118,6 +118,11 @@ public class HiveGui implements Listener {
                     if (bee == null || bee.type() != beeSlot) {
                         return;
                     }
+                    // Prevent replacing an existing bee so it doesn't get lost
+                    if (current != null && !current.getType().isAir()
+                            && !current.getType().toString().endsWith("GLASS_PANE")) {
+                        return;
+                    }
                     if (event.getClick() == ClickType.RIGHT && cursor.getAmount() > 1) {
                         ItemStack one = cursor.clone();
                         one.setAmount(1);


### PR DESCRIPTION
## Summary
- Prevent placing a bee on top of an existing bee in hive GUI slots

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d701b228832a9d4144882d7eda22